### PR TITLE
Translations for 'Functional' section

### DIFF
--- a/project/translate-zh.scala
+++ b/project/translate-zh.scala
@@ -168,13 +168,13 @@ object translate {
                 "### 模式匹配")
   translate += (">Pattern Matching<" -> 
                 ">模式匹配<")
-  translate += ("Pattern Matching is more flexible than switch-case; And it's simpler than if-else." -> 
+  translate += ("Pattern Matching is more flexible than switch-case and simpler than if-else." ->
                 "模式匹配是类似switch-case特性，但更加灵活；也类似if-else，但更加简约。")
-  translate += ("This example shows Fibonacci function with pattern matching." -> 
+  translate += ("This example shows a Fibonacci function implemented with pattern matching." ->
                 "这个例子展示的使用用模式匹配实现斐波那契。")
-  translate += ("The case keyword is to matching. The case _ means it can match anything." -> 
+  translate += ("The case keyword matches on a value. The case _ means it can match anything." ->
                 "使用case来匹配参数，如果case _，则可以匹配任何参数。") 
-  translate += ("But the example has a bug. If the input is negative number, it would loop endless." -> 
+  translate += ("But the example has a bug. If the input is a negative number, it will loop endlessly." ->
                 "这个例子有所不足，当输入负数时，会无限循环。") 
   translate += ("Try to add if after case. Change case n: Int to case n: Int if (n > 1)." -> 
                 "可以在case后添加if语句判断，将case n: Int 修改为 case n: Int if (n > 1)即可。") 
@@ -201,9 +201,9 @@ translate += ("to match String type." ->
                 "还添加了hashcode,equals和toString等方法。") 
   translate += ("Try to append println(Sum(1,2)) last." -> 
                 "试试最后添加  println(Sum(1,2)) 。") 
-  translate += ("Because of the require(n >= 0), it would throw exception when input is negative." -> 
+  translate += ("Because of the require(n >= 0), it will throw an exception when the input is negative." ->
                 "由于使用了require(n >= 0)来检验参数，尝试使用负数，会抛出异常。") 
-  translate += ("Because of the require(n &gt;= 0), it would throw exception when input is negative." -> 
+  translate += ("Because of the require(n &gt;= 0), it will throw an exception when the input is negative." ->
                 "由于使用了require(n &gt;= 0)来检验参数，如果使用负数计算，将会抛出异常。") 
 
 
@@ -211,14 +211,14 @@ translate += ("to match String type." ->
                 "### 函数式的威力") 
   translate += (">Function Power<" -> 
                 ">函数式的威力<") 
-  translate += ("This example shows whether there is an odd in list." -> 
+  translate += ("This example determines whether there is an odd number in the list." ->
                 "这个例子是判断一个List中是否含有奇数。") 
-    translate += ("This example shows whether there is an odd in list by imperative programming." -> 
+    translate += ("This example determines whether there is an odd number in the list using imperative programming." ->
                 "这个例子是用指令式编程判断一个List中是否含有奇数。") 
 
-  translate += ("The code from the 1st line to the last but one is created by imperative programming." -> 
+  translate += ("Every line of the code excluding the last line is created using imperative programming." ->
                 "第一行到倒数第二行是使用for循环的指令式编程解决。") 
-  translate += ("And the last line is created by functional programming." -> 
+  translate += ("The last line is created using functional programming." ->
                 "最后一行是通过函数式编程解决。") 
   translate += ("Treating function expression as function arguments can simplify code effectively." -> 
                 "通过将函数作为参数，可以使程序极为简洁。")
@@ -233,9 +233,9 @@ translate += ("to match String type." ->
                 "### 函数式真正的威力")
   translate += (">Function True Power<" -> 
                 ">函数式真正的威力<")
-  translate += ("Besides simplifying code, the functional programming more take care of Input & Output without side-effect." -> 
+  translate += ("Besides simplifying code, functional programming is more concerned with Input & Output without side-effects." ->
                 "函数式除了能简化代码外，更重要的是他关注的是Input和Output，函数本身没有副作用。")
-  translate += ("Besides simplifying code, the functional programming more take care of <span class=\"important\">Input & Output without side-effect</span>." -> 
+  translate += ("Besides simplifying code, functional programming is more concerned with <span class=\"important\">Input & Output without side-effects</span>." ->
                 "函数式除了能简化代码外，更重要的是他关注的是<span class=\"important\">Input</span>和<span class=\"important\">Output</span>，函数本身没有副作用。")
 
   translate += ("Like the Unix pipeline, simple commands can be combined together." -> 
@@ -246,13 +246,13 @@ translate += ("to match String type." ->
 
   translate += ("The filter method in List can accept a filter function to return a new List." -> 
                 "List的filter方法接受一个过滤函数，返回一个新的List。")
-  translate += ("If you do like the Unix pipeline style, functional programming can be your favorite." -> 
+  translate += ("If you like the way Unix pipelines commands, you may also like functional programming" ->
                 "如果你喜欢Unix pipeline的方式，你一定也会喜欢函数式编程。")
-  translate += ("This example is to use Scala code to simulate the function of \"cat file | grep 'warn' | grep '2013' | wc.\"" -> 
+  translate += ("This example uses Scala code to simulate the Unix command line \"cat file | grep 'warn' | grep '2013' | wc.\"" ->
                 "这个例子是用函数式的代码模拟“cat file | grep 'warn' | grep '2013' | wc”的行为。")
- translate += ("This example is to use Scala code to simulate the function of " -> 
+ translate += ("This example uses Scala code to simulate the function of " ->
                 "这个例子是用函数式的代码模拟")
- translate += ("The filter function in List can accept a filter function, return a new List as the input of the next function." -> 
+ translate += ("The first filter function in List accepts a function as an argument, returning a new filtered List as the input to the next function." ->
                 "List的filter方法接受一个过滤函数，返回一个新的List，作为下一个方法的输入。")
 
 

--- a/project/translate-zh.scala
+++ b/project/translate-zh.scala
@@ -261,37 +261,37 @@ translate += ("to match String type." ->
 
   translate += ("### Word Count" -> 
                 "### Word Count")
-  translate += ("Word Count is a classics sample for Map Reduce. " -> 
+  translate += ("Word Count is a classic use case for Map Reduce. " ->
                 "Word Count是一个MapReduce的一个经典示例。")
   translate += ("Map Reduce with functional programming is also a wonderful way to implement word count." -> 
                 "巧合的是，使用函数式的编程法，用类似MapReduce的方法实现word count也是最直观的。")
-  translate += ("Map Reduce with functional programming is also a great way to implement word count." -> 
+  translate += ("Map Reduce with functional programming is an intuitive solution to the Word Count problem." ->
                 "在函数式编程中，Word Count最直观的实现方法也是MapReduce。")
 
 
-  translate += ("The example show two important functions 'map' and 'reduceLeft' in List." -> 
+  translate += ("The example shows two important functions 'map' and 'reduceLeft' in List." ->
                 "这个例子介绍了List的两个重要的高阶方法map和reduceLeft。")
-  translate += ("The example show two important functions <span class=\"important\">'map'</span> and <span class=\"important\">'reduceLeft'</span> in List." -> 
+  translate += ("The example shows two important functions <span class=\"important\">'map'</span> and <span class=\"important\">'reduceLeft'</span> in List." ->
                 "这个例子介绍了List的两个重要的高阶方法<span class=\"important\">map</span>和<span class=\"important\">reduceLeft</span>。")
 
 
-  translate += ("The map function accepts a translate expression and return the list translated." -> 
+  translate += ("The map function accepts a translation expression and returns the translated list." ->
                 "List的map方法接受一个转换函数，返回一个经过转换的List。")
 
-  translate += ("The <span class=\"important\">map</span> function accepts a translate expression and return the list translated." -> 
+  translate += ("The <span class=\"important\">map</span> function accepts a translation expression and returns the translated list." ->
                 "<span class=\"important\">map</span>接受一个转换函数,返回转换结果。")
 
 
 
 
-  translate += ("The reduceLeft function accepts a combine expression and return the combined result." -> 
+  translate += ("The reduceLeft function accepts a combining expression and returns the combined result." ->
                 "List的reduceLeft方法接受一个合并函数，依次遍历合并。")
 
-  translate += ("The <span class=\"important\">reduceLeft</span> function accepts a combine expression and return the combined result." -> 
+  translate += ("The <span class=\"important\">reduceLeft</span> function accepts a combining expression and returns the combined result." ->
                 "<span class=\"important\">reduceLeft</span>接受一个合并函数，依次遍历合并。")
 
 
-  translate += ("<span class=\"important\">Map and FoldLeft can replace the for-loop expression, it make code cleaner.</span>" -> 
+  translate += ("<span class=\"important\">Map and ReduceLeft can replace a for-loop expression, making code cleaner.</span>" ->
                 "<span class=\"important\">使用高阶方法可以代替大部分需要循环的操作，使代码更清晰。</span>")
 
 
@@ -301,28 +301,28 @@ translate += ("to match String type." ->
                 "将reduceLeft(_ + _)修改为foldLeft(0)(_ + _)。")
   translate += ("foldLeft is more popular than reduceLeft for it can provide a initial value." -> 
                 "foldLeft比将reduceLeft更常用，因为他可以提供一个初始参数。")
-  translate += ("Map and foldLeft can replace the for-loop expression, it make code cleaner." -> 
+  translate += ("Map and ReduceLeft can replace a for-loop expression, making code cleaner." ->
                 "Map和foldLeft可以代替大部分需要for循环的操作，并且使代码更清晰")
   translate += ("### Tail Recursion" -> 
                 "### 尾递归")
   translate += (">Tail Recursion<" -> 
                 ">尾递归<")
-  translate += ("This example show how to implement foldLeft with Tail Recursion" -> 
+  translate += ("This example shows how to implement foldLeft with Tail Recursion" ->
                 "这个例子是用尾递归实现foldLeft。")
   translate += ("Tail Recursion is very popular in functional programming." -> 
                 "尾递归是函数式编程的常见写法。")
    translate += ("This example shows how to implement foldLeft with Tail Recursion." -> 
                 "这个例子是foldLeft的尾递归实现。foldLeft和reduceLeft相比更常用，多一个初始参数。") 
 
-  translate += ("Tail Recursion is one type of Recursion, it call itself in its last expression. " -> 
+  translate += ("Tail Recursion is one type of Recursion, in which a function calls itself as its last expression. " ->
                 "尾递归是递归的一种，特点在于会在函数的最末调用自身。")
-  translate += ("List can be pattern match by '::', the first elements returned is head, the others are tails." -> 
+  translate += ("Lists can be pattern matched by '::', the first element returned is head, the others are tails." ->
                 "当用List做match case时，可以使用 :: 来解构。返回第一个元素head，和剩余元素tail。")
-  translate += ("List can be pattern match by '::', the first elements returned is head, and the others are tails." -> 
+  translate += ("Lists can be pattern matched by '::', the first element returned is head, and the others are the tail." ->
                 "当用List做match case时，可以使用 :: 来解构。返回第一个元素head和剩余元素tail。")
-    translate += ("Tail Recursion can be optimized in compile time. So it not need to worry about stack overflow." -> 
+    translate += ("Tail Recursion can be optimized at compile time. So there's no need to worry about stack overflow." ->
                 "尾递归会在编译期优化，因此不用担心一般递归造成的栈溢出问题。")
-  translate += ("PS: Tail Recursion can be optimized in compile time. So it not need to worry about stack overflow." -> 
+  translate += ("PS: Tail Recursion can be optimized at compile time. So there's no need to worry about stack overflow." ->
                 "注：尾递归会在编译期优化，因此不用担心递归造成的栈溢出问题。")
   translate += ("### Powerful For Expression" -> 
                 "### 更强大的For")
@@ -330,13 +330,13 @@ translate += ("to match String type." ->
                 ">更强大的For循环<")
   translate += ("Loop expression is feature of imperative programming.So Scala improved it to suit functional programming." -> 
                 "循环语句是指令式编程的特产，Scala对其加以改进，成为适应函数式风格的利器。")
-  translate += ("For-Loop is common feature of imperative programming. So Scala improved it to fit functional programming." -> 
+  translate += ("For-Loop is a common feature in imperative programming. Scala improved it to suit functional programming." ->
                 "循环语句是指令式编程的常见语句，Scala对其加以改进，成为适应函数式风格的利器。")
-  translate += ("For expression in Scala can also return a List. " -> 
+  translate += ("For expressions in Scala can also return a List. " ->
                 "For循环也是有返回值的，其返回是一个List。")
-  translate += ("For-Loop expression in Scala can also return a List. " -> 
+  translate += ("For-Loop expressions in Scala can also return a List. " ->
                 "For循环也是有返回值的，返回的是一个List。")
-  translate += ("With 'yield' in loop, value after yield can append to the List." -> 
+  translate += ("With 'yield' in the loop, the value after yield will be appended to the List." ->
                 "在每一轮迭代中加入yield，yield后的值可以加入到List中。")
   translate += ("This example replaces the map function with for loop." -> 
                 "这个例子是使用for循环代替map函数。")
@@ -344,25 +344,25 @@ translate += ("to match String type." ->
                 "### Option")
   translate += ("NullException is the most common exception in Java. The only way to avoid it is to check null everywhere." -> 
                 "NullException是Java中最常见的异常，要想避免他只有不断检查null。")
-  translate += ("Scala provide a Option feature to avoid checking null everywhere." -> 
+  translate += ("Scala provides an Option feature to avoid checking null everywhere." ->
                 "Scala提供了Option机制来解决，代码中不断检查null的问题。")
 
 
-  translate += ("Scala provide a Option feature to solve it." -> 
+  translate += ("Scala provides an Option feature to solve it." ->
                 "Scala提供了Option机制来解决。")
-  translate += ("This example create a getProperty function, and it would return Option instead of null." -> 
+  translate += ("This example creates a getProperty function, which returns Option instead of null." ->
                 "这个例子包装了可能返回null的getProperty方法，使其返回一个Option。")
-  translate += ("This example has a getProperty function, and it would return Option instead of null." -> 
+  translate += ("This example creates a getProperty function, which returns Option instead of null." ->
                 "这个例子包装了getProperty方法，使其返回一个Option。")
-  translate += ("So we do not check null everywhere, getting value from Option is enough." -> 
+  translate += ("We don't need to check null, getting a value from Option is enough." ->
                 "这样就可以不再漫无目的地null检查。只要Option类型的值即可。")
-  translate += ("Using pattern match is a common way to get value from Option.    " -> 
+  translate += ("Using pattern matching is a common way to get the value of Option.    " ->
                 "使用pattern match来检查是常见做法。")
-  translate += ("It can also use getOrElse() to set a default value when it's none." -> 
+  translate += ("Use getOrElse() to set a default value when Option is None." ->
                 "也可以使用getOrElse来提供当为None时的默认值。")
   translate += ("Another important think is that Option has lots of functions in List, so it can work like a list in most of time." -> 
                 "给力的是Option还可以看作是最大长度为1的List，其的强大功能都可以使用。")
-    translate += ("Another important thing is that Option contains lots of functions in List, so it can work like a list in most of time." -> 
+    translate += ("Another important thing is that Option contains lots of functions in List, so it can be used like a list most of time." ->
                 "给力的是Option还可以看作是最大长度为1的List，List的强大功能都可以使用。")
 
   translate += ("Try to add 'osName.foreach(print _)' at last." -> 
@@ -372,17 +372,17 @@ translate += ("to match String type." ->
   translate += (">Lazy Initialization<" -> 
                 ">Lazy初始化<")
 
-  translate += ("Lazy can lazy initial value." -> 
+  translate += ("Lazy can lazily initialize value." ->
                 "Lazy可以延迟初始化字段。")
 
 
   translate += ("Lazy is lazy initial value. " -> 
                 "Lazy可以延迟初始化。")
-  translate += ("The fields with lazy key word can initial when it first access." -> 
+  translate += ("A field with the lazy keyword is only initialized when it is first accessed." ->
                 "加上lazy的字段会在第一次访问的时候初始化。")
-    translate += ("The fields with lazy keyword can initial when it first access." -> 
+    translate += ("A field with the lazy keyword is only initialized when it is first accessed." ->
                 "加上lazy的字段会在第一次访问的时候初始化，而不是类初始化的时候初始化。")
-  translate += ("This example is to get the Scala Version Code from Github. It takes time because of network latency. " -> 
+  translate += ("This example is to get the Scala Version Code from Github. It takes a little time because of network latency. " ->
                 "这个例子是从github获得Scala的版本号，由于访问网络需要较多时间。")
   translate += ("It waste of time that if we get it with latency but we do not use it later." -> 
                 "如果费尽力气获取到，而调用它的代码却不去访问就会很浪费。")
@@ -544,7 +544,7 @@ translate += ("to match String type." ->
                 "Scala和Java可以非常方便的互操作，前面已经有大量Scala直接使用Java的例子。")
   translate += ("Java can also use Scala. " -> 
                 "同样Java也可以使用Scala。")
-  translate += ("This example show how to use @BeanProperty Annotation to create Java Style Bean." -> 
+  translate += ("This example shows how to use @BeanProperty Annotation to create Java Style Bean." ->
                 "这个例子演示使用@BeanProperty注解来生成Java Style的Bean。")
   translate += ("Try to add @BeanProperty before var name. So that the bean contains getter/setter." -> 
                 "尝试将在var name前加上@BeanProperty。这样就给bean添加了getter/setter")

--- a/scala-tour.md
+++ b/scala-tour.md
@@ -334,12 +334,12 @@ println("cat file | grep 'warn' | grep '2013' | wc : "
     + file.filter(_.contains("warn")).filter(_.contains("2013")).size)
 ```
 ### Word Count
-Word Count is a classics sample for Map Reduce. Map Reduce with functional programming is also a wonderful way to implement word count.
-The example show two important functions 'map' and 'reduceLeft' in List.
-The map function accepts a translate expression and return the list translated.
-The reduceLeft function accepts a combine expression and return the combined result.The first argument is the reduced value, and the second argument is the value next.
+Word Count is a classic use case for Map Reduce. Map Reduce with functional programming is also a wonderful way to implement word count.
+The example shows two important functions 'map' and 'reduceLeft' in List.
+The map function accepts a translation expression and returns the translated list.
+The reduceLeft function accepts a combining expression and returns the combined result.The first argument is the reduced value, and the second argument is the value next.
 Try to change reduceLeft(_ + _) into foldLeft(0)(_ + _).foldLeft is more popular than reduceLeft for it can provide a initial value.
-Map and foldLeft can replace the for-loop expression, it make code cleaner.
+Map and ReduceLeft can replace a for-loop expression, making code cleaner.
 
 ```
 val file = List("warn 2013 msg", "warn 2012 msg", "error 2013 msg", "warn 2013 msg")
@@ -352,9 +352,9 @@ println("wordcount:" + num)
 ```
 ### Tail Recursion
 
-This example show how to implement foldLeft with Tail RecursionTail Recursion is one type of Recursion, it call itself in its last expression. 
-List can be pattern match by '::', the first elements returned is head, and the others are tails.
-Tail Recursion can be optimized in compile time. So it not need to worry about stack overflow.
+This example shows how to implement foldLeft with Tail RecursionTail Recursion is one type of Recursion, in which a function calls itself as its last expression.
+Lists can be pattern matched by '::', the first element returned is head, and the others are the tail.
+Tail Recursion can be optimized at compile time. So there's no need to worry about stack overflow.
 
 ```
 val file = List("warn 2013 msg", "warn 2012 msg", "error 2013 msg", "warn 2013 msg")
@@ -376,7 +376,7 @@ println("wordcount:" + num)
 ### Powerful For Expression
 
 Loop expression is feature of imperative programming.So Scala improved it to suit functional programming.
-For expression in Scala can also return a List. With 'yield' in loop, value after yield can append to the List.
+For expressions in Scala can also return a List. With 'yield' in the loop, the value after yield will be appended to the List.
 This example replaces the map function with for loop.
 
 ```
@@ -394,10 +394,10 @@ println("wordcount:" + num)
 ```
 ### Option
 
-NullException is the most common exception in Java. The only way to avoid it is to check null everywhere.Scala provide a Option feature to solve it.
-This example create a getProperty function, and it would return Option instead of null.
-So we do not check null everywhere, getting value from Option is enough.
-Using pattern match is a common way to get value from Option.    It can also use getOrElse() to set a default value when it's none.
+NullException is the most common exception in Java. The only way to avoid it is to check null everywhere.Scala provides an Option feature to solve it.
+This example creates a getProperty function, which returns Option instead of null.
+We don't need to check null, getting a value from Option is enough.
+Using pattern matching is a common way to get the value of Option.    Use getOrElse() to set a default value when Option is None.
 Another important think is that Option has lots of functions in List, so it can work like a list in most of time.
 Try to add 'osName.foreach(print _)' at last.
 
@@ -425,8 +425,8 @@ println(osName.getOrElse("none"))
 
 ### Lazy
 
-Lazy is lazy initial value. The fields with lazy key word can initial when it first access.
-This example is to get the Scala Version Code from Github. It takes time because of network latency. 
+Lazy is lazy initial value. A field with the lazy keyword is only initialized when it is first accessed.
+This example is to get the Scala Version Code from Github. It takes a little time because of network latency.
 It waste of time that if we get it with latency but we do not use it later.
 So we can get it with lazy.
 
@@ -653,7 +653,7 @@ system.shutdown
 ### Using Java
 
 Scala can operate Java very easily. There have been lots of samples before.
-Java can also use Scala. This example show how to use @BeanProperty Annotation to create Java Style Bean.
+Java can also use Scala. This example shows how to use @BeanProperty Annotation to create Java Style Bean.
 Try to add @BeanProperty before var name. So that the bean contains getter/setter.
 And the Apache BeanUtils can work correctly.
 

--- a/scala-tour.md
+++ b/scala-tour.md
@@ -248,10 +248,10 @@ println("Json: " + list.toString())
 
 ### Pattern Matching
 
-Pattern Matching is more flexible than switch-case; And it's simpler than if-else.
-This example shows Fibonacci function with pattern matching.
-The case keyword is to matching. The case _ means it can match anything.
-But the example has a bug. If the input is negative number, it would loop endless.
+Pattern Matching is more flexible than switch-case and simpler than if-else.
+This example shows a Fibonacci function implemented with pattern matching.
+The case keyword matches on a value. The case _ means it can match anything.
+But the example has a bug. If the input is a negative number, it will loop endlessly.
 Try to add if after case. Change case n: Int to case n: Int if (n > 1).
 Try to add case n: String => fibonacci(n.toInt) before case _ to match String type.
 Try to add println(fibonacci(-3))；println(fibonacci("3")) to test the program. 
@@ -274,7 +274,7 @@ Case classes are used to conveniently store and match on the contents of a class
 You can construct them without using new.
 It also has hashcode, equality and nice toString methods.
 Try to append println(Sum(1,2)) last.
-Because of the require(n >= 0), it would throw exception when input is negative.
+Because of the require(n >= 0), it will throw an exception when the input is negative.
 
 
 ```
@@ -298,8 +298,8 @@ println(value(FibonacciExpr(3)))
 
 ### The power of functional programing
 
-This example shows whether there is an odd in list.
-The code from the 1st line to the last but one is created by imperative programming.And the last line is created by functional programming.
+This example determines whether there is an odd number in the list.
+Every line of the code excluding the last line is created using imperative programming.The last line is created using functional programming.
 Treating function expression as function arguments can simplify code effectively.The _ % 2 == 1 is the syntactic sugar of (x: Int) => x % 2 == 1.
 Ruby's power is from magic, but Scala's power is from science.
 
@@ -321,11 +321,11 @@ println("list containsOdd by funtional:" + list.exists(_ % 2 == 1))
 
 ### The true power of functional programming
 
-Besides simplifying code, the functional programming more take care of Input & Output without side-effect.
+Besides simplifying code, functional programming is more concerned with Input & Output without side-effects.
 Like the Unix pipeline, simple commands can be combined together.
 The filter method in List can accept a filter function to return a new List.
-If you do like the Unix pipeline style, functional programming can be your favorite.
-This example is to use Scala code to simulate the function of "cat file | grep 'warn' | grep '2013' | wc."
+If you like the way Unix pipelines commands, you may also like functional programming
+This example uses Scala code to simulate the Unix command line "cat file | grep 'warn' | grep '2013' | wc."
 
 ```
 val file = List("warn 2013 msg", "warn 2012 msg", "error 2013 msg", "warn 2013 msg")

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -769,10 +769,10 @@ println(fibonacci(3))
                     <div class="span4">
                         <h2>Pattern Matching</h2>
                         <p>
-                            Pattern Matching is more flexible than switch-case; And it's simpler than if-else.
+                            Pattern Matching is more flexible than switch-case and simpler than if-else.
                         </p>
                         <p>
-                            This example shows Fibonacci function with pattern matching. The case keyword is to matching. The case _ means it can match anything.
+                            This example shows a Fibonacci function implemented with pattern matching. The case keyword matches on a value. The case _ means it can match anything.
                         </p>
                         <p>
                             Try to change
@@ -847,7 +847,7 @@ println(value(FibonacciExpr(3)))
                             You can construct them without using new. It also has hashcode, equality and nice toString methods.
                         </p>
                         <p>
-                            Because of the require(n &gt;= 0), it would throw exception when input is negative.
+                            Because of the require(n &gt;= 0), it will throw an exception when the input is negative.
                         </p>
                         <div class="step-nav">
                             <a class="btn pre-step" type="button"><i class="icon-arrow-left">&nbsp;</i>Prev Page</a> <a class="btn" type="button" href="#/funtional-contents"><i class="icon-arrow-up">&nbsp;</i>Content</a> <a class="btn next-step" type="button"><i class="icon-arrow-right">&nbsp;</i>Next Page</a>
@@ -890,7 +890,7 @@ println("list contains Odd ? " + containsOdd(list))
                     <div class="span4">
                         <h2>Function Power</h2>
                         <p>
-                            This example shows whether there is an odd in list by imperative programming.
+                            This example determines whether there is an odd number in the list using imperative programming.
                         </p>
                         <p>
                             Try to change
@@ -905,7 +905,7 @@ containsOdd(list)
 list.exists((x: Int) =&gt; x % 2 ==1)
 </pre>
                         <p>
-                            Through treating function as arguments, programing can be more simple. It can be even changed to 
+                            Through treating function as arguments, programing can be more simple. It can be even changed to
                         </p>
                         <pre>
 list.exists(_ % 2 == 1)
@@ -950,22 +950,22 @@ println("cat file | grep 'warn' | grep '2013' | wc : "
                     <div class="span4">
                         <h2>Function True Power</h2>
                         <p>
-                            Besides simplifying code, the functional programming more take care of <span class="important">Input & Output without side-effect</span>.
+                            Besides simplifying code, functional programming is more concerned with <span class="important">Input & Output without side-effects</span>.
                         </p>
                         <p>
                             Like the Unix pipeline, simple commands can be combined together.
                         </p>
                         <p>
-                            If you do like the Unix pipeline style, functional programming can be your favorite.
+                            If you like the way Unix pipelines commands, you may also like functional programming
                         </p>
                         <p>
-                            This example is to use Scala code to simulate the function of 
+                            This example uses Scala code to simulate the function of
                         </p>
                         <pre>
 cat file | grep 'warn' | grep '2013' | wc
 </pre>
                         <p>
-                            The filter function in List can accept a filter function, return a new List as the input of the next function.
+                            The first filter function in List accepts a function as an argument, returning a new filtered List as the input to the next function.
                         </p>
                         <div class="step-nav">
                             <a class="btn pre-step" type="button"><i class="icon-arrow-left">&nbsp;</i>Prev Page</a> <a class="btn" type="button" href="#/funtional-contents"><i class="icon-arrow-up">&nbsp;</i>Content</a> <a class="btn next-step" type="button"><i class="icon-arrow-right">&nbsp;</i>Next Page</a>

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1006,19 +1006,19 @@ println("wordcount:" + num)
                             Word Count
                         </h2>
                         <p>
-                            Word Count is a classics sample for Map Reduce. Map Reduce with functional programming is also a great way to implement word count.
+                            Word Count is a classic use case for Map Reduce. Map Reduce with functional programming is an intuitive solution to the Word Count problem.
                         </p>
                         <p>
-                            The example show two important functions <span class="important">'map'</span> and <span class="important">'reduceLeft'</span> in List.
+                            The example shows two important functions <span class="important">'map'</span> and <span class="important">'reduceLeft'</span> in List.
                         </p>
                         <p>
-                            The <span class="important">map</span> function accepts a translate expression and return the list translated.
+                            The <span class="important">map</span> function accepts a translation expression and returns the translated list.
                         </p>
                         <p>
-                            The <span class="important">reduceLeft</span> function accepts a combine expression and return the combined result.
+                            The <span class="important">reduceLeft</span> function accepts a combining expression and returns the combined result.
                         </p>
                         <p>
-                            <span class="important">Map and FoldLeft can replace the for-loop expression, it make code cleaner.</span>
+                            <span class="important">Map and ReduceLeft can replace a for-loop expression, making code cleaner.</span>
                         </p>
                         <div class="step-nav">
                             <a class="btn pre-step" type="button"><i class="icon-arrow-left">&nbsp;</i>Prev Page</a> <a class="btn" type="button" href="#/funtional-contents"><i class="icon-arrow-up">&nbsp;</i>Content</a> <a class="btn next-step" type="button"><i class="icon-arrow-right">&nbsp;</i>Next Page</a>
@@ -1064,16 +1064,16 @@ println("wordcount:" + num)
                     <div class="span4">
                         <h2>Tail Recursion</h2>
                         <p>
-                            Tail Recursion is one type of Recursion, it call itself in its last expression. Tail Recursion is very popular in functional programming.
+                            Tail Recursion is one type of Recursion, in which a function calls itself as its last expression. Tail Recursion is very popular in functional programming.
                         </p>
                         <p>
                             This example shows how to implement foldLeft with Tail Recursion.
                         </p>
                         <p>
-                            List can be pattern match by '::', the first elements returned is head, and the others are tails.
+                            Lists can be pattern matched by '::', the first element returned is head, and the others are the tail.
                         </p>
                         <p>
-                            PS: Tail Recursion can be optimized in compile time. So it not need to worry about stack overflow.
+                            PS: Tail Recursion can be optimized at compile time. So there's no need to worry about stack overflow.
                         </p>
                         <div class="step-nav">
                             <a class="btn pre-step" type="button"><i class="icon-arrow-left">&nbsp;</i>Prev Page</a> <a class="btn" type="button" href="#/funtional-contents"><i class="icon-arrow-up">&nbsp;</i>Content</a> <a class="btn next-step" type="button"><i class="icon-arrow-right">&nbsp;</i>Next Page</a>
@@ -1116,10 +1116,10 @@ println("wordcount:" + num)
                     <div class="span4">
                         <h2>Powerful For Loop</h2>
                         <p>
-                            For-Loop is common feature of imperative programming. So Scala improved it to fit functional programming.
+                            For-Loop is a common feature in imperative programming. Scala improved it to suit functional programming.
                         </p>
                         <p>
-                            For-Loop expression in Scala can also return a List. With 'yield' in loop, value after yield can append to the List.
+                            For-Loop expressions in Scala can also return a List. With 'yield' in the loop, the value after yield will be appended to the List.
                         </p>
                         <p>
                             This example replaces the map function with for loop.
@@ -1170,16 +1170,16 @@ osName.foreach(print _)
                             Option
                         </h2>
                         <p>
-                            Scala provide a Option feature to avoid checking null everywhere.
+                            Scala provides an Option feature to avoid checking null everywhere.
                         </p>
                         <p>
-                            This example has a getProperty function, and it would return Option instead of null. So we do not check null everywhere, getting value from Option is enough.
+                            This example creates a getProperty function, which returns Option instead of null. We don't need to check null, getting a value from Option is enough.
                         </p>
                         <p>
-                            Using pattern match is a common way to get value from Option.    It can also use getOrElse() to set a default value when it's none.
+                            Using pattern matching is a common way to get the value of Option.    Use getOrElse() to set a default value when Option is None.
                         </p>
                         <p>
-                            Another important thing is that Option contains lots of functions in List, so it can work like a list in most of time.
+                            Another important thing is that Option contains lots of functions in List, so it can be used like a list most of time.
                         </p>
                         <p>
                             Goodbye NullException.
@@ -1227,10 +1227,10 @@ version.minorVersion.foreach(println _)
                     <div class="span4">
                         <h2>Lazy Initialization</h2>
                         <p>
-                            Lazy can lazy initial value.The fields with lazy keyword can initial when it first access.
+                            Lazy can lazily initialize value.A field with the lazy keyword is only initialized when it is first accessed.
                         </p>
                         <p>
-                            This example is to get the Scala Version Code from Github. It takes time because of network latency. So we can get it with lazy to avoid unnecessary IO blocking.
+                            This example is to get the Scala Version Code from Github. It takes a little time because of network latency. So we can get it with lazy to avoid unnecessary IO blocking.
                         </p>
                         <p>
                             Lazy is very suitable for the value takes lots of resources.
@@ -1793,7 +1793,7 @@ println(BeanUtils.describe(bean))
                             Scala can operate Java very easily. There have been lots of samples before.
                         </p>
                         <p>
-                            Java can also use Scala. This example show how to use @BeanProperty Annotation to create Java Style Bean.
+                            Java can also use Scala. This example shows how to use @BeanProperty Annotation to create Java Style Bean.
                         </p>
                         <p>
                             Try to change


### PR DESCRIPTION
Hi Yan.

I've made some adjustments to the English translation of the Functional section.  A couple of the English translations ended up being exactly the same but the Chinese looks different (strings are longer); for example; line 381 and line 383 in `project/translate-zh.scala`  

Also, I've changed the last line of the Map Reduce section:

`Map and ReduceLeft can replace a for-loop expression, making code cleaner.`

The search/replace I used updated this in multiple places. On line 295 of `project/translate-zh.scala`, I don't see `foldLeft` in the Chinese translation.  

On line 305, I did not change `Map和foldLeft可以代替大部分需要for循环的操作，并且使代码更清晰` because I wasn't sure where the word boundary for `foldLeft` is and whether or not this was the proper target of the translation. You _might_ want to change `ReduceLeft` on line 304 back to `foldLeft`. If you do this, the site (http://www.scala-tour.com/#/word-count) will not make sense because there's no `foldLeft` on that page. However, it does make sense in the text version.

Thanks.
