### PR TITLE
Security

### DIFF
--- a/policy
+++ b/policy
@@ -6,6 +6,8 @@ grant {
   permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe/-", "read";
   permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe.akka", "read";
   permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe.akka/-", "read";
+  permission java.io.FilePermission "./target/specs2-reports", "read, write";
+  permission java.io.FilePermission "./target/specs2-reports/-", "read, write";
 
   permission java.io.FilePermission "/tmp", "read";
 

--- a/policy
+++ b/policy
@@ -1,0 +1,40 @@
+/* AUTOMATICALLY GENERATED ON Sat Aug 10 20:31:30 PDT 2013*/
+/* DO NOT EDIT */
+
+grant {
+  permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe", "read";
+  permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe/-", "read";
+  permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe.akka", "read";
+  permission java.io.FilePermission "${user.home}/.ivy2/cache/com.typesafe.akka/-", "read";
+
+  permission java.io.FilePermission "/tmp", "read";
+
+  permission java.io.FilePermission "/usr/lib/jvm/java-*/-", "read";
+  permission java.io.FilePermission "/usr/lib/jvm/java-*/jre/-", "read";
+  permission java.io.FilePermission "/usr/java/packages/lib/ext/-", "read";
+  permission java.io.FilePermission "/usr/java/packages/lib/ext", "read";
+  permission java.io.FilePermission "/usr/share/java/-", "read";
+
+  permission java.util.PropertyPermission "java.version", "read";
+  permission java.util.PropertyPermission "java.vendor", "read";
+  permission java.util.PropertyPermission "os.name", "read";
+  permission java.util.PropertyPermission "os.version", "read";
+  permission java.util.PropertyPermission "os.arch", "read";
+
+  permission java.io.FilePermission "/proc/self/stat", "read";
+
+  permission java.net.SocketPermission "github.com:443", "connect, resolve";
+  permission java.net.SocketPermission "raw.github.com:443", "connect, resolve";
+  permission java.net.SocketPermission "scala-lang.org:80", "connect, resolve";
+  permission java.net.SocketPermission "127.0.0.1:2552", "connect, resolve, listen, accept";
+
+  permission java.lang.RuntimePermission "getenv.AKKA_HOME", "read";
+  permission java.util.PropertyPermission "akka.home", "read";
+  permission java.util.PropertyPermission "*", "read, write";
+  permission java.lang.RuntimePermission "setContextClassLoader";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+  permission java.lang.RuntimePermission "accessClassInPackage.sun.misc";
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.RuntimePermission "modifyThread";
+};
+

--- a/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
+++ b/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
@@ -45,6 +45,8 @@ object ScalaScriptCompiler {
     command.settings.feature.value = true
     command.settings.language.appendToValue("reflectiveCalls")
     command.settings.language.appendToValue("implicitConversions")
+    command.settings.nospecialization.value = true
+    command.settings.nouescape.value = true
     command.settings;
   }
 

--- a/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
+++ b/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
@@ -140,7 +140,7 @@ object ScalaScriptProcess {
 
 class ScalaScriptProcess(val builder: ProcessBuilder, val logger: ProcessLogger) {
   def run(): Process = {
-    println(builder.toString)
+    // println(builder.toString)
     builder.run(logger);
   }
 }

--- a/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
+++ b/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
@@ -53,7 +53,7 @@ object ScalaScriptCompiler {
   def compile(script: String, err: OutputStream): Option[File] = {
     val scriptFile = File.makeTemp("scala-script", ".scala")
     // save the command to the file
-   
+
     val illegalCodePattern = """.*(\.sys\.).*""".r
 
     val strippedScript = {
@@ -123,9 +123,9 @@ object ScalaScriptProcess {
   }
 
   def create(compiledLocation: File, out: OutputStream, err: OutputStream): Option[ScalaScriptProcess] = {
-
-    val CP = Properties.propOrEmpty("java.class.path") + Properties.propOrEmpty("path.separator") + compiledLocation
-    var args = List("-cp", CP, "Main")
+    val policy = new java.io.File("policy")
+    val CP = Properties.propOrEmpty("java.class.path") + Properties.propOrEmpty("path.separator") + compiledLocation + Properties.propOrEmpty("path.separator") + "."
+    var args = List("-Djava.security.manager", "-Djava.security.policy=" + policy.getAbsolutePath ,"-cp", CP, "Main")
     if (Path(javaf()).exists) {
       val outp = new PrintStream(out, true);
       val errp = new PrintStream(err, true);
@@ -140,6 +140,7 @@ object ScalaScriptProcess {
 
 class ScalaScriptProcess(val builder: ProcessBuilder, val logger: ProcessLogger) {
   def run(): Process = {
+    println(builder.toString)
     builder.run(logger);
   }
 }

--- a/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
+++ b/src/main/scala/com/yankay/scalaTour/ScalaScriptRunner.scala
@@ -52,7 +52,7 @@ object ScalaScriptCompiler {
     val scriptFile = File.makeTemp("scala-script", ".scala")
     // save the command to the file
    
-    val illegalCodePattern = """.*import .*""".r
+    val illegalCodePattern = """.*(\.sys\.).*""".r
 
     val strippedScript = {
       if (illegalCodePattern.findAllIn(script).toList.isEmpty) script


### PR DESCRIPTION
Yan,

I tweaked the security policy file used by [scripster](https://github.com/razie/scripster) to make all examples on scala-tour.com pass except the Remote Actors example.

Please evaluate. If I get a chance sometime next week, I'll look into the changes necessary to make the Remote Actors example work properly

This policy file should be a bit more robust than a whitelist as mentioned in yankay/scala-tour#6, because it allows you to whitelist not only imported packages, but file access, network access, and other things.

To edit this `policy` file, just execute `policytool` and you'll have a gui for editing the file.

Thanks,

Jim
